### PR TITLE
Allow JS/CSS to be loaded over ssl. Fixes #26

### DIFF
--- a/crisp/default.hbs
+++ b/crisp/default.hbs
@@ -9,8 +9,8 @@
 	    <meta name="description" content="{{meta_description}}" />
 	    <link rel="shortcut icon" href="{{@blog.logo}}"/>
 			{{! Styles }}
-	    <link href='http://fonts.googleapis.com/css?family=Open+Sans:300italic,700italic,300,700' rel='stylesheet' type='text/css'>
-			<link href='http://fonts.googleapis.com/css?family=Bree+Serif' rel='stylesheet' type='text/css'>
+	    <link href='//fonts.googleapis.com/css?family=Open+Sans:300italic,700italic,300,700' rel='stylesheet' type='text/css'>
+			<link href='//fonts.googleapis.com/css?family=Bree+Serif' rel='stylesheet' type='text/css'>
 			<link href="//netdna.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.css" rel="stylesheet">
 			<link rel="stylesheet" type="text/css" href="{{asset '/styles/crisp.css'}}">
 			{{! Responsive Meta Tags }}

--- a/crisp/partials/share.hbs
+++ b/crisp/partials/share.hbs
@@ -109,7 +109,7 @@
       </li> 
   </ul>	
 </div>
-<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
 <script src="{{asset '/js/rrssb.min.js'}}"></script>
 {{#contentFor "head"}}
 	<link rel="stylesheet" type="text/css" href="{{asset '/styles/rrssb.css'}}">


### PR DESCRIPTION
This allows google fonts & jquery to be loaded over SSL. Keeps users from getting security warnings from their browser.