### PR TITLE
Set background color to white explicitly.

### DIFF
--- a/assets/styles/crisp.css
+++ b/assets/styles/crisp.css
@@ -8,7 +8,8 @@ html, body {
 	line-height: 1.65em;
 	font-family: "Open Sans", sans-serif;
 	font-weight: 300;
-	color:#444;
+    background: #fff;
+	color: #444;
 }
 html {
 	height: 100%;


### PR DESCRIPTION
With this pull request, the background color of pages using the Crisp theme is explicitly set to white. Most browsers do have white as the default background color, but sadly not all do. The WebKit-based browser that is used in Steam, for example, has black as its default background color - which makes Crisp look terrible.